### PR TITLE
Add time totals to all report modes (#65)

### DIFF
--- a/date-range-reporter/index.html
+++ b/date-range-reporter/index.html
@@ -897,7 +897,7 @@
             </div>
             <div class="toggle-row">
               <div class="toggle-content">
-                <label for="showTotalTime">Show total project time</label>
+                <label for="showTotalTime">Show totals</label>
               </div>
               <label class="toggle-switch">
                 <input type="checkbox" id="showTotalTime" checked style="display: none;" />
@@ -1478,11 +1478,33 @@
           }
         }
 
+        // Sum the displayed time (parent own-time + subtasks) for a date's task list,
+        // mirroring the per-line expressions used when rendering below.
+        const showTotals = document.getElementById('showTotalTime')?.checked;
+        function sumDateGroupMs(tasks, dateStr) {
+          let ms = 0;
+          tasks.forEach(task => {
+            const d = task.workLogDate || dateStr;
+            if (task.timeSpentOnDay && task.timeSpentOnDay[d]) ms += task.timeSpentOnDay[d];
+            if (task.subtasks && task.subtasks.length > 0) {
+              task.subtasks.forEach(subtask => {
+                const sd = subtask.workLogDate || dateStr;
+                if (subtask.timeSpentOnDay && subtask.timeSpentOnDay[sd]) ms += subtask.timeSpentOnDay[sd];
+              });
+            }
+          });
+          return ms;
+        }
+
         // Generate report in Markdown format
         let reportText = `# Task Completion Report\n\n`;
         reportText += `**Date Range:** ${formatDateDisplay(formatDate(startDate))} - ${formatDateDisplay(formatDate(endDate))}  \n`;
         reportText += `**Generated:** ${new Date().toLocaleString()}  \n`;
         reportText += `**Total Tasks:** ${totalTasks}\n`;
+        if (showTotals) {
+          const grandTotalMs = Object.keys(tasksByDate).reduce((sum, dateStr) => sum + sumDateGroupMs(tasksByDate[dateStr], dateStr), 0);
+          reportText += `**Total Time:** ${formatTime(Math.round(grandTotalMs / 60000))}\n`;
+        }
         if (excludedCountRef.count > 0) {
           reportText += `**Excluded Work Logs:** ${excludedCountRef.count} (below ${document.getElementById('minTimeSpent').value} min threshold)\n`;
         }
@@ -1501,7 +1523,8 @@
 
         datesToShow.forEach(dateStr => {
           const tasks = tasksByDate[dateStr];
-          reportText += `## ${formatDateDisplay(dateStr)}\n\n`;
+          const dateTotalDisplay = showTotals ? ` *(total: ${formatTime(Math.round(sumDateGroupMs(tasks, dateStr) / 60000))})*` : '';
+          reportText += `## ${formatDateDisplay(dateStr)}${dateTotalDisplay}\n\n`;
 
           if (tasks.length === 0) {
             reportText += `*No tasks*\n\n`;
@@ -1681,10 +1704,15 @@
         }
 
         // Generate report in Markdown format
+        const showTotals = document.getElementById('showTotalTime')?.checked;
         let reportText = `# Task Completion Report\n\n`;
         reportText += `**Date Range:** ${formatDateDisplay(formatDate(startDate))} - ${formatDateDisplay(formatDate(endDate))}  \n`;
         reportText += `**Generated:** ${new Date().toLocaleString()}  \n`;
         reportText += `**Total Tasks:** ${totalTasks}\n`;
+        if (showTotals) {
+          const grandTotalMinutes = Math.round(Object.values(tasksByProject).reduce((sum, p) => sum + p.totalTime, 0) / 60000);
+          reportText += `**Total Time:** ${formatTime(grandTotalMinutes)}\n`;
+        }
         if (excludedCountRef.count > 0) {
           reportText += `**Excluded Work Logs:** ${excludedCountRef.count} (below ${document.getElementById('minTimeSpent').value} min threshold)\n`;
         }
@@ -2286,7 +2314,7 @@
       // the showTimeSpent flag which affects the time column values.  The
       // `headerLabel` map should contain human-readable column titles for
       // whatever column keys are present in `cols`.
-      function renderTableRows(groups, cols, showTimeSpent, headerLabel) {
+      function renderTableRows(groups, cols, showTimeSpent, headerLabel, showTotalRow = false) {
         let text = '';
         Object.keys(groups).forEach(groupKey => {
           let rows = groups[groupKey] || [];
@@ -2332,10 +2360,23 @@
             });
           });
 
+          // Build the optional Total row cells so their width is accounted for below
+          let totalCells = null;
+          if (showTotalRow && rows.length > 0) {
+            const totalMinutes = rows.reduce((sum, r) => sum + (r.timeMinutes || 0), 0);
+            const labelIdx = cols.findIndex(c => c !== 'time');
+            totalCells = cols.map((c, i) => {
+              if (c === 'time') return `**${formatTime(totalMinutes)}**`;
+              if (i === labelIdx) return '**Total**';
+              return '';
+            });
+          }
+
           const widths = cols.map((c, idx) => {
             const headerLen = headerLabel[c].length;
             const maxCell = cellValues.reduce((max, row) => Math.max(max, (row[idx]||'').length), 0);
-            return Math.max(headerLen, maxCell);
+            const totalLen = totalCells ? (totalCells[idx]||'').length : 0;
+            return Math.max(headerLen, maxCell, totalLen);
           });
           const padded = (str, w) => str + ' '.repeat(Math.max(0, w - str.length));
 
@@ -2360,6 +2401,10 @@
 
             text += `| ${cells.join(' | ')} |\n`;
           });
+
+          if (totalCells) {
+            text += `| ${totalCells.map((v, i) => padded(v, widths[i])).join(' | ')} |\n`;
+          }
 
           text += `\n`;
         });
@@ -2492,12 +2537,19 @@
         const headerLabel = { date: 'Date', project: 'Project', title: 'Task Title', time: 'Time Spent', status: 'Status', notes: 'Notes' };
 
         // Build markdown table output header (rest of rows handled by helper)
+        const showTotals = document.getElementById('showTotalTime')?.checked;
         let reportText = `# Task Completion Report\n\n`;
         reportText += `**Date Range:** ${formatDateDisplay(formatDate(startDate))} - ${formatDateDisplay(formatDate(endDate))}  \n`;
         reportText += `**Generated:** ${new Date().toLocaleString()}  \n`;
-        reportText += `**Total Tasks:** ${processedTaskIds.size}\n\n`;
-        // delegate row construction to helper
-        reportText += renderTableRows(groups, cols, showTimeSpent, headerLabel);
+        reportText += `**Total Tasks:** ${processedTaskIds.size}\n`;
+        if (showTotals) {
+          const totalMinutes = entries.reduce((sum, e) => sum + (e.timeMinutes || 0), 0);
+          reportText += `**Total Time:** ${formatTime(totalMinutes)}\n`;
+        }
+        reportText += `\n`;
+        // delegate row construction to helper; append a Total row only when the Time column is shown
+        const showTotalRow = showTotals && showTimeSpent && cols.includes('time');
+        reportText += renderTableRows(groups, cols, showTimeSpent, headerLabel, showTotalRow);
         
         return { reportText, totalTasks: processedTaskIds.size };
       }

--- a/date-range-reporter/index.html
+++ b/date-range-reporter/index.html
@@ -1484,13 +1484,17 @@
         function sumDateGroupMs(tasks, dateStr) {
           let ms = 0;
           tasks.forEach(task => {
-            const d = task.workLogDate || dateStr;
-            if (task.timeSpentOnDay && task.timeSpentOnDay[d]) ms += task.timeSpentOnDay[d];
+            // A parent's own time is redundant with its subtasks' time, so count
+            // subtasks when present, otherwise the parent's own time. This matches
+            // the project-grouped report's no-double-count policy.
             if (task.subtasks && task.subtasks.length > 0) {
               task.subtasks.forEach(subtask => {
                 const sd = subtask.workLogDate || dateStr;
                 if (subtask.timeSpentOnDay && subtask.timeSpentOnDay[sd]) ms += subtask.timeSpentOnDay[sd];
               });
+            } else {
+              const d = task.workLogDate || dateStr;
+              if (task.timeSpentOnDay && task.timeSpentOnDay[d]) ms += task.timeSpentOnDay[d];
             }
           });
           return ms;
@@ -2314,6 +2318,26 @@
       // the showTimeSpent flag which affects the time column values.  The
       // `headerLabel` map should contain human-readable column titles for
       // whatever column keys are present in `cols`.
+      // Sum timeMinutes across table rows without double-counting parent + subtask
+      // time. Subtask rows share their parent's taskId and carry a '↳ ' title
+      // prefix; when a task has subtask rows only those count (the parent's own
+      // time is redundant), matching the project-grouped report's totals.
+      function sumRowMinutesNoDoubleCount(rows) {
+        const byTask = new Map();
+        rows.forEach((r, i) => {
+          const key = (r.taskId != null) ? `id:${r.taskId}` : `row:${i}`;
+          if (!byTask.has(key)) byTask.set(key, []);
+          byTask.get(key).push(r);
+        });
+        let total = 0;
+        byTask.forEach(group => {
+          const subtaskRows = group.filter(r => typeof r.title === 'string' && r.title.startsWith('↳ '));
+          const counted = subtaskRows.length > 0 ? subtaskRows : group;
+          total += counted.reduce((sum, r) => sum + (r.timeMinutes || 0), 0);
+        });
+        return total;
+      }
+
       function renderTableRows(groups, cols, showTimeSpent, headerLabel, showTotalRow = false) {
         let text = '';
         Object.keys(groups).forEach(groupKey => {
@@ -2363,7 +2387,7 @@
           // Build the optional Total row cells so their width is accounted for below
           let totalCells = null;
           if (showTotalRow && rows.length > 0) {
-            const totalMinutes = rows.reduce((sum, r) => sum + (r.timeMinutes || 0), 0);
+            const totalMinutes = sumRowMinutesNoDoubleCount(rows);
             const labelIdx = cols.findIndex(c => c !== 'time');
             totalCells = cols.map((c, i) => {
               if (c === 'time') return `**${formatTime(totalMinutes)}**`;
@@ -2543,7 +2567,7 @@
         reportText += `**Generated:** ${new Date().toLocaleString()}  \n`;
         reportText += `**Total Tasks:** ${processedTaskIds.size}\n`;
         if (showTotals) {
-          const totalMinutes = entries.reduce((sum, e) => sum + (e.timeMinutes || 0), 0);
+          const totalMinutes = sumRowMinutesNoDoubleCount(entries);
           reportText += `**Total Time:** ${formatTime(totalMinutes)}\n`;
         }
         reportText += `\n`;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -3412,6 +3412,39 @@ describe('Date Range Reporter', () => {
       expect(reportText).toContain('**Total Time:** 1h'); // grand total
       expect(reportText).toContain('*(total: 1h)*');      // per-project subtotal (existing behavior)
     });
+
+    // A parent's own time is redundant with its subtasks' time; totals must count
+    // subtasks only (never both), and must agree across all three report modes.
+    it('does not double-count parent + subtask time, and totals agree across modes', async () => {
+      // Parent logs 1h of its own time but has a subtask that logs 30m.
+      // Correct total = 30m (subtask only), NOT 1h30m.
+      const withSubtask = () => ([
+        { id: 'parent', title: 'Parent', projectId: 'p1', isDone: true, doneOn: new Date('2024-01-15T12:00:00').getTime(), timeSpentOnDay: { '2024-01-15': 3600000 } },
+        { id: 'child', parentId: 'parent', title: 'Child', projectId: 'p1', isDone: true, doneOn: new Date('2024-01-15T12:00:00').getTime(), timeSpentOnDay: { '2024-01-15': 1800000 } }
+      ]);
+      mockPluginAPI.getAllProjects.mockResolvedValue([{ id: 'p1', title: 'Project Alpha' }]);
+      document.getElementById('showTotalTime').checked = true;
+      setRange('2024-01-15', '2024-01-15');
+
+      async function totalLineFor(outputFormat, groupBy) {
+        mockPluginAPI.getTasks.mockResolvedValue(withSubtask());
+        document.getElementById('outputFormat').value = outputFormat;
+        document.getElementById('groupBy').value = groupBy;
+        await window.generateReport();
+        const text = document.getElementById('modalReportContent').value;
+        return text.match(/\*\*Total Time:\*\* (.+)/)[1].trim();
+      }
+
+      const projectTotal = await totalLineFor('simple', 'project');
+      const dateTotal = await totalLineFor('simple', 'date');
+      const tableTotal = await totalLineFor('table', 'date');
+
+      // No double-count: 30m, not 1h 30m
+      expect(projectTotal).toBe('30m');
+      // All three modes agree
+      expect(dateTotal).toBe(projectTotal);
+      expect(tableTotal).toBe(projectTotal);
+    });
   });
 
   describe('Storage Compression & Limits', () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -2368,16 +2368,18 @@ describe('Date Range Reporter', () => {
       const startInput = document.getElementById('startDate');
       const endInput = document.getElementById('endDate');
       const showTimeSpent = document.getElementById('showTimeSpent');
-      
+      const showTotalTime = document.getElementById('showTotalTime');
+
       startInput.value = '2024-01-15';
       endInput.value = '2024-01-15';
       showTimeSpent.checked = false;
+      showTotalTime.checked = false; // isolate showTimeSpent: no group/grand totals either
 
       await window.generateReport();
 
       const modalContent = document.getElementById('modalReportContent');
       const reportText = modalContent.value;
-      
+
       expect(reportText).toContain('Test Task');
       expect(reportText).not.toContain('60 min');
       expect(reportText).not.toContain('*(');
@@ -3310,6 +3312,105 @@ describe('Date Range Reporter', () => {
       const firstIndex = reportText.indexOf('Big Task');
       const secondIndex = reportText.indexOf('Small Task');
       expect(firstIndex).toBeLessThan(secondIndex);
+    });
+  });
+
+  describe('Report Totals', () => {
+    const twoTasks = () => ([
+      { id: 'a', title: 'Task A', isDone: true, doneOn: new Date('2024-01-15T12:00:00').getTime(), timeSpentOnDay: { '2024-01-15': 7200000 } }, // 2h
+      { id: 'b', title: 'Task B', isDone: true, doneOn: new Date('2024-01-16T12:00:00').getTime(), timeSpentOnDay: { '2024-01-16': 1800000 } }  // 30m
+    ]);
+
+    function setRange(start, end) {
+      document.getElementById('startDate').value = start;
+      document.getElementById('endDate').value = end;
+    }
+
+    it('table output shows grand total in metadata and a Total row', async () => {
+      mockPluginAPI.getTasks.mockResolvedValue(twoTasks());
+      document.getElementById('outputFormat').value = 'table';
+      document.getElementById('showTotalTime').checked = true;
+      setRange('2024-01-15', '2024-01-16');
+
+      await window.generateReport();
+      const reportText = document.getElementById('modalReportContent').value;
+
+      expect(reportText).toContain('**Total Time:** 2h 30m'); // metadata line
+      expect(reportText).toContain('**Total**');               // total row label
+      expect(reportText).toContain('**2h 30m**');              // total row value (bold, distinct from metadata)
+    });
+
+    it('table output omits totals when showTotalTime is unchecked', async () => {
+      mockPluginAPI.getTasks.mockResolvedValue(twoTasks());
+      document.getElementById('outputFormat').value = 'table';
+      document.getElementById('showTotalTime').checked = false;
+      setRange('2024-01-15', '2024-01-16');
+
+      await window.generateReport();
+      const reportText = document.getElementById('modalReportContent').value;
+
+      expect(reportText).not.toContain('**Total Time:**');
+      expect(reportText).not.toContain('**Total**');
+    });
+
+    it('table grand total shows but Total row is suppressed when showTimeSpent is off', async () => {
+      mockPluginAPI.getTasks.mockResolvedValue(twoTasks());
+      document.getElementById('outputFormat').value = 'table';
+      document.getElementById('showTotalTime').checked = true;
+      document.getElementById('showTimeSpent').checked = false;
+      setRange('2024-01-15', '2024-01-16');
+
+      await window.generateReport();
+      const reportText = document.getElementById('modalReportContent').value;
+
+      expect(reportText).toContain('**Total Time:** 2h 30m'); // metadata summary still shown
+      expect(reportText).not.toContain('**Total**');           // in-table row needs the Time column populated
+    });
+
+    it('date grouping shows per-date subtotals and a grand total', async () => {
+      mockPluginAPI.getTasks.mockResolvedValue(twoTasks());
+      document.getElementById('outputFormat').value = 'simple';
+      document.getElementById('groupBy').value = 'date';
+      document.getElementById('showTotalTime').checked = true;
+      setRange('2024-01-15', '2024-01-16');
+
+      await window.generateReport();
+      const reportText = document.getElementById('modalReportContent').value;
+
+      expect(reportText).toContain('**Total Time:** 2h 30m');
+      expect(reportText).toContain('*(total: 2h)*');  // Jan 15
+      expect(reportText).toContain('*(total: 30m)*'); // Jan 16
+    });
+
+    it('date grouping omits totals when showTotalTime is unchecked', async () => {
+      mockPluginAPI.getTasks.mockResolvedValue(twoTasks());
+      document.getElementById('outputFormat').value = 'simple';
+      document.getElementById('groupBy').value = 'date';
+      document.getElementById('showTotalTime').checked = false;
+      setRange('2024-01-15', '2024-01-16');
+
+      await window.generateReport();
+      const reportText = document.getElementById('modalReportContent').value;
+
+      expect(reportText).not.toContain('**Total Time:**');
+      expect(reportText).not.toContain('*(total:');
+    });
+
+    it('project grouping shows a grand total alongside per-project subtotals', async () => {
+      mockPluginAPI.getAllProjects.mockResolvedValue([{ id: 'p1', title: 'Project Alpha' }]);
+      mockPluginAPI.getTasks.mockResolvedValue([
+        { id: 'a', title: 'Task A', projectId: 'p1', isDone: true, doneOn: new Date('2024-01-15T12:00:00').getTime(), timeSpentOnDay: { '2024-01-15': 3600000 } }
+      ]);
+      document.getElementById('outputFormat').value = 'simple';
+      document.getElementById('groupBy').value = 'project';
+      document.getElementById('showTotalTime').checked = true;
+      setRange('2024-01-15', '2024-01-15');
+
+      await window.generateReport();
+      const reportText = document.getElementById('modalReportContent').value;
+
+      expect(reportText).toContain('**Total Time:** 1h'); // grand total
+      expect(reportText).toContain('*(total: 1h)*');      // per-project subtotal (existing behavior)
     });
   });
 


### PR DESCRIPTION
Closes #65.

## What
Every report mode now surfaces time totals, gated on the existing checkbox (relabeled **"Show total project time" → "Show totals"** since it now governs more than project headings):

- **Grand total** (`**Total Time:**`) in the metadata block of all three modes (project-grouped, date-grouped, Markdown table).
- **Per-date subtotals** on date-group headings: `## <date> *(total: 1h 20m)*`, mirroring the existing project-heading format.
- **Flat table** keeps its shape (per earlier discussion — not sectioned) and gains a `**Total**` row summing the Time column.

## Behavior
- Totals follow `showTotalTime` and are **independent of** `showTimeSpent`, matching the pre-existing project-grouping contract.
- The in-table `**Total**` row only appears when the Time column is shown and `showTimeSpent` is on; the metadata grand total shows whenever totals are on.

## Tests
- New `Report Totals` describe block (6 tests) covering table / date / project totals and the `showTotalTime` / `showTimeSpent` gating.
- Full suite green: **121 passed**.

## Notes
- **Stacked on `fix/issue-66-storage-limit`** (base branch) because #66 is unmerged and heavily rewrites the same two files; retarget to `main` once #66 merges.
- Source only — the gitignored `date-range-reporter.zip` build artifact is regenerated via `make build`/`make release`.
- No version bump included.