### PR TITLE
Add task tags to reports (#68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A plugin for [Super Productivity](https://super-productivity.com) that generates
 - 📅 Select custom date ranges for reporting
 - 📊 View all tasks completed or worked on within the selected period
 - 🔀 **Group reports by Date or by Project** for different perspectives
-- 🏷️ Optionally show project names when grouping by date
+- 🏷️ Optionally show project names alongside tasks (Show project toggle)
+- 🏷️ Optionally show task tags as `#tag` tokens (Show tags toggle, off by default)
 - 📆 Optionally show completion dates when grouping by project
 - ⏱️ Automatic time aggregation per project with totals
 - ⏳ Includes in-progress tasks that have work logs in the date range
@@ -75,6 +76,8 @@ The generated report is formatted in Markdown and includes:
 - Individual work log entries for tasks with multiple work logs
 - WIP indicator for work in progress entries (before task completion)
 - Time spent on each task (when tracked)
+- Optional project name in brackets, e.g. `[Project A]` (Show project toggle, on by default)
+- Optional task tags as `#tag` tokens, e.g. `#backlog #security` (Show tags toggle, off by default; the special "Today" tag is omitted)
 - Optional task notes (when enabled)
 - OVERDUE indicator for tasks that passed their planned date without completion (when enabled)
 

--- a/date-range-reporter/index.html
+++ b/date-range-reporter/index.html
@@ -879,6 +879,15 @@
             </div>
             <div class="toggle-row">
               <div class="toggle-content">
+                <label for="showTags">Show tags</label>
+              </div>
+              <label class="toggle-switch">
+                <input type="checkbox" id="showTags" style="display: none;" />
+                <span class="toggle-slider"></span>
+              </label>
+            </div>
+            <div class="toggle-row">
+              <div class="toggle-content">
                 <label for="includeNotes">Show task notes</label>
               </div>
               <label class="toggle-switch">
@@ -1053,6 +1062,7 @@
       var preferences = {
         groupBy: 'date',
         showProject: true,
+        showTags: false,
         showDate: false,
         excludeEmptyDates: true,
         includeNotes: false,
@@ -1099,6 +1109,22 @@
         const hours = Math.floor(minutes / 60);
         const mins = minutes % 60;
         return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+      }
+
+      // Resolve a task's tagIds to Markdown tokens like "#foo #bar".
+      // The special SuperProductivity "Today" tag is skipped (it's scheduling
+      // state, not a real category) and whitespace in tag titles is slugified
+      // so multi-word tags stay a single token (e.g. "in progress" -> #in-progress).
+      // `tags` is an id -> title lookup. Returns a bare token string (no leading
+      // space); callers add spacing as needed.
+      function formatTaskTags(tagIds, tags) {
+        if (!Array.isArray(tagIds) || tagIds.length === 0 || !tags) return '';
+        return tagIds
+          .filter(id => id && id !== 'TODAY')
+          .map(id => tags[id])
+          .filter(Boolean)
+          .map(title => '#' + String(title).trim().replace(/\s+/g, '-'))
+          .join(' ');
       }
 
       // Get all dates in range
@@ -1291,7 +1317,7 @@
       }
 
       // Generate report grouped by date
-      function generateReportByDate(allTasks, startDate, endDate, projects) {
+      function generateReportByDate(allTasks, startDate, endDate, projects, tags) {
         const tasksByDate = {};
         let totalTasks = 0;
 
@@ -1531,6 +1557,7 @@
         const excludeEmpty = document.getElementById('excludeEmptyDates').checked;
         const includeNotes = document.getElementById('includeNotes').checked;
         const showProject = document.getElementById('showProject')?.checked !== false;
+        const showTags = document.getElementById('showTags')?.checked === true;
         const datesToShow = excludeEmpty
           ? sortedDates.filter(dateStr => tasksByDate[dateStr].length > 0)
           : sortedDates;
@@ -1563,8 +1590,11 @@
               const projectName = showProject && task.projectId && projects[task.projectId]
                 ? ` [${projects[task.projectId]}]`
                 : '';
+              // Optionally show tags
+              const tagTokens = showTags ? formatTaskTags(task.tagIds, tags) : '';
+              const taskTags = tagTokens ? ` ${tagTokens}` : '';
 
-              reportText += `- ${task.title}${projectName}${timeSpent}${statusIndicator}\n`;
+              reportText += `- ${task.title}${projectName}${taskTags}${timeSpent}${statusIndicator}\n`;
               
               // Include subtasks indented under parent task
               if (task.subtasks && task.subtasks.length > 0) {
@@ -1577,8 +1607,10 @@
                   const subtaskProjectName = showProject && subtask.projectId && projects[subtask.projectId]
                     ? ` [${projects[subtask.projectId]}]`
                     : '';
+                  const subtaskTagTokens = showTags ? formatTaskTags(subtask.tagIds, tags) : '';
+                  const subtaskTags = subtaskTagTokens ? ` ${subtaskTagTokens}` : '';
 
-                  reportText += `  - ${subtask.title}${subtaskProjectName}${subtaskTimeSpent}${subtaskStatusIndicator}\n`;
+                  reportText += `  - ${subtask.title}${subtaskProjectName}${subtaskTags}${subtaskTimeSpent}${subtaskStatusIndicator}\n`;
                   
                   // Include notes for subtask if applicable
                   if (includeNotes && subtask.notes && subtask.notes.trim()) {
@@ -1603,7 +1635,7 @@
       }
 
       // Generate report grouped by project
-      function generateReportByProject(allTasks, startDate, endDate, projects) {
+      function generateReportByProject(allTasks, startDate, endDate, projects, tags) {
         const tasksByProject = {};
         const processedTasks = new Set();
         let totalTasks = 0;
@@ -1743,7 +1775,8 @@
         // Filter out empty projects if checkbox is checked
         const excludeEmpty = document.getElementById('excludeEmptyDates').checked;
         const includeNotes = document.getElementById('includeNotes').checked;
-        const projectsToShow = excludeEmpty 
+        const showTags = document.getElementById('showTags')?.checked === true;
+        const projectsToShow = excludeEmpty
           ? sortedProjects.filter(projectId => tasksByProject[projectId].tasks.length > 0)
           : sortedProjects;
 
@@ -1771,8 +1804,11 @@
                 statusIndicator = ' DONE ✅';
               }
               
-              // For project grouping, don't show dates
-              reportText += `- ${task.title}${timeSpent}${statusIndicator}\n`;
+              // For project grouping, don't show dates. Project is already the
+              // heading, so only tags are appended inline.
+              const tagTokens = showTags ? formatTaskTags(task.tagIds, tags) : '';
+              const taskTags = tagTokens ? ` ${tagTokens}` : '';
+              reportText += `- ${task.title}${taskTags}${timeSpent}${statusIndicator}\n`;
               
               // Include notes if checkbox is checked and task has notes
               if (includeNotes && task.notes && task.notes.trim()) {
@@ -1787,9 +1823,10 @@
                   const subtaskTimeMinutes = Math.round(subtask.totalTimeSpent / 60000);
                   const subtaskTimeSpent = (document.getElementById('showTimeSpent').checked && subtaskTimeMinutes > 0) ? ` *(${formatTime(subtaskTimeMinutes)})*` : '';
                   const subtaskStatusIndicator = subtask.isInProgress ? ' WIP' : (subtask.isDone ? ' DONE ✅' : '');
-                  
-                  
-                  reportText += `  - ${subtask.title}${subtaskTimeSpent}${subtaskStatusIndicator}\n`;
+                  const subtaskTagTokens = showTags ? formatTaskTags(subtask.tagIds, tags) : '';
+                  const subtaskTags = subtaskTagTokens ? ` ${subtaskTagTokens}` : '';
+
+                  reportText += `  - ${subtask.title}${subtaskTags}${subtaskTimeSpent}${subtaskStatusIndicator}\n`;
                   
                   // Include notes for subtask if applicable
                   if (includeNotes && subtask.notes && subtask.notes.trim()) {
@@ -1839,6 +1876,17 @@
           } catch (e) {
             console.warn('Could not load projects:', e);
           }
+
+          // Get all tags to map tagId to tag title
+          const tags = {};
+          try {
+            const allTagsList = await PluginAPI.getAllTags();
+            allTagsList.forEach(tag => {
+              tags[tag.id] = tag.title;
+            });
+          } catch (e) {
+            console.warn('Could not load tags:', e);
+          }
           
           // Combine all tasks
           const allTasks = [...archivedTasks, ...activeTasks];
@@ -1850,17 +1898,17 @@
           let totalTasks = 0;
 
           if (outputFormat === 'table') {
-            const result = generateReportAsTable(allTasks, startDate, endDate, projects);
+            const result = generateReportAsTable(allTasks, startDate, endDate, projects, tags);
             reportText = result.reportText;
             totalTasks = result.totalTasks;
           } else if (groupBy === 'date') {
             // Group by date logic
-            const result = generateReportByDate(allTasks, startDate, endDate, projects);
+            const result = generateReportByDate(allTasks, startDate, endDate, projects, tags);
             reportText = result.reportText;
             totalTasks = result.totalTasks;
           } else {
             // Group by project logic
-            const result = generateReportByProject(allTasks, startDate, endDate, projects);
+            const result = generateReportByProject(allTasks, startDate, endDate, projects, tags);
             reportText = result.reportText;
             totalTasks = result.totalTasks;
           }
@@ -2189,6 +2237,7 @@
         const groupByEl = document.getElementById('groupBy');
         const showDateEl = document.getElementById('showDate');
         const showProjectEl = document.getElementById('showProject');
+        const showTagsEl = document.getElementById('showTags');
         const excludeEmptyDatesEl = document.getElementById('excludeEmptyDates');
         const includeNotesEl = document.getElementById('includeNotes');
         const includeOverdueEl = document.getElementById('includeOverdue');
@@ -2200,6 +2249,7 @@
         if (groupByEl) groupByEl.value = preferences.groupBy;
         if (showDateEl) showDateEl.checked = preferences.showDate;
         if (showProjectEl) showProjectEl.checked = preferences.showProject;
+        if (showTagsEl) showTagsEl.checked = preferences.showTags;
         if (excludeEmptyDatesEl) excludeEmptyDatesEl.checked = preferences.excludeEmptyDates;
         if (includeNotesEl) includeNotesEl.checked = preferences.includeNotes;
         if (includeOverdueEl) includeOverdueEl.checked = preferences.includeOverdue;
@@ -2239,12 +2289,16 @@
         const list = document.getElementById('tableColumnsList');
         if (!list) return;
 
-        const defaultCols = ['date','project','title','time','status','notes'];
+        const defaultCols = ['date','project','tags','title','time','status','notes'];
         // start with saved order or defaults
         let cols = (preferences.tableColumns && Array.isArray(preferences.tableColumns)) ? preferences.tableColumns.slice() : defaultCols.slice();
         // ensure defaults are always available (user might remove notes but want to re-add later)
         defaultCols.forEach(c => { if (!cols.includes(c)) cols.push(c); });
-        const labels = { date: 'Date', project: 'Project', title: 'Task Title', time: 'Time Spent', status: 'Status', notes: 'Notes' };
+        // the Tags column only exists when Show tags is enabled, so keep it out
+        // of the orderable list until then
+        const showTags = document.getElementById('showTags')?.checked === true;
+        if (!showTags) cols = cols.filter(c => c !== 'tags');
+        const labels = { date: 'Date', project: 'Project', tags: 'Tags', title: 'Task Title', time: 'Time Spent', status: 'Status', notes: 'Notes' };
 
         list.innerHTML = '';
         cols.forEach(key => {
@@ -2396,6 +2450,7 @@
             return cols.map(c => {
               if (c === 'date') return formatDateDisplay(r.date);
               if (c === 'project') return r.project || '';
+              if (c === 'tags') return escapeCell(r.tags || '');
               if (c === 'title') return r.title;
               if (c === 'time') return (showTimeSpent && r.timeMinutes) ? formatTime(r.timeMinutes) : (showTimeSpent ? '0m' : '');
               if (c === 'status') return r.status || '';
@@ -2434,6 +2489,7 @@
               let val = '';
               if (c === 'date') val = formatDateDisplay(r.date);
               else if (c === 'project') val = r.project || '';
+              else if (c === 'tags') val = escapeCell(r.tags || '');
               else if (c === 'title') val = r.title;
               else if (c === 'time') val = (showTimeSpent && r.timeMinutes) ? formatTime(r.timeMinutes) : (showTimeSpent ? '0m' : '');
               else if (c === 'status') val = r.status || '';
@@ -2455,7 +2511,7 @@
         return text;
       }
 
-      function generateReportAsTable(allTasks, startDate, endDate, projects) {
+      function generateReportAsTable(allTasks, startDate, endDate, projects, tags) {
         const minTimeMs = parseInt(document.getElementById('minTimeSpent').value) * 60000;
         // const includeNotes = document.getElementById('includeNotes').checked; // not used in table logic
         const showTimeSpent = document.getElementById('showTimeSpent').checked;
@@ -2494,24 +2550,24 @@
               workLogsInRange.forEach(workLogDate => {
                 const timeMinutes = Math.round((task.timeSpentOnDay && task.timeSpentOnDay[workLogDate] ? task.timeSpentOnDay[workLogDate] / 60000 : 0));
                 const status = workLogDate !== taskDateStr ? 'WIP' : 'DONE';
-                pushEntry({ date: workLogDate, project: projects[task.projectId] || '', title: task.title, timeMinutes, status, notes: task.notes || '', taskId: task.id });
+                pushEntry({ date: workLogDate, project: projects[task.projectId] || '', title: task.title, timeMinutes, status, tags: formatTaskTags(task.tagIds, tags), notes: task.notes || '', taskId: task.id });
 
                 const filteredSubtasks = filterSubtasksForReport(subtasks, formatDate(startDate), formatDate(endDate), minTimeMs);
                 filteredSubtasks.forEach(subtask => {
                   const subDate = subtask.workLogDate || workLogDate;
                   const subTimeMinutes = subtask.timeSpentOnDay && subtask.timeSpentOnDay[subDate] ? Math.round(subtask.timeSpentOnDay[subDate] / 60000) : 0;
-                  pushEntry({ date: subDate, project: projects[subtask.projectId] || projects[task.projectId] || '', title: '↳ ' + subtask.title, timeMinutes: subTimeMinutes, status: subtask.isInProgress ? 'WIP' : (subtask.isDone ? 'DONE' : ''), notes: subtask.notes || '', taskId: task.id });
+                  pushEntry({ date: subDate, project: projects[subtask.projectId] || projects[task.projectId] || '', title: '↳ ' + subtask.title, timeMinutes: subTimeMinutes, status: subtask.isInProgress ? 'WIP' : (subtask.isDone ? 'DONE' : ''), tags: formatTaskTags(subtask.tagIds, tags), notes: subtask.notes || '', taskId: task.id });
                 });
               });
             } else if ((taskDateStr >= formatDate(startDate) && taskDateStr <= formatDate(endDate)) || subtasksWithLogsInRange.length > 0) {
               const timeMinutes = (task.timeSpentOnDay && task.timeSpentOnDay[taskDateStr]) ? Math.round(task.timeSpentOnDay[taskDateStr] / 60000) : 0;
-              pushEntry({ date: taskDateStr, project: projects[task.projectId] || '', title: task.title, timeMinutes, status: 'DONE', notes: task.notes || '', taskId: task.id });
+              pushEntry({ date: taskDateStr, project: projects[task.projectId] || '', title: task.title, timeMinutes, status: 'DONE', tags: formatTaskTags(task.tagIds, tags), notes: task.notes || '', taskId: task.id });
 
               const filteredSubtasks = filterSubtasksForReport(subtasks, formatDate(startDate), formatDate(endDate), minTimeMs);
               filteredSubtasks.forEach(subtask => {
                 const subDate = subtask.workLogDate || taskDateStr;
                 const subTimeMinutes = subtask.timeSpentOnDay && subtask.timeSpentOnDay[subDate] ? Math.round(subtask.timeSpentOnDay[subDate] / 60000) : 0;
-                pushEntry({ date: subDate, project: projects[subtask.projectId] || projects[task.projectId] || '', title: '↳ ' + subtask.title, timeMinutes: subTimeMinutes, status: subtask.isInProgress ? 'WIP' : (subtask.isDone ? 'DONE' : ''), notes: subtask.notes || '', taskId: task.id });
+                pushEntry({ date: subDate, project: projects[subtask.projectId] || projects[task.projectId] || '', title: '↳ ' + subtask.title, timeMinutes: subTimeMinutes, status: subtask.isInProgress ? 'WIP' : (subtask.isDone ? 'DONE' : ''), tags: formatTaskTags(subtask.tagIds, tags), notes: subtask.notes || '', taskId: task.id });
               });
             }
           } else if (hasWorkLogs || subtasksWithLogsInRange.length > 0) {
@@ -2519,7 +2575,7 @@
               Object.keys(task.timeSpentOnDay).forEach(workLogDate => {
                 if (workLogDate >= formatDate(startDate) && workLogDate <= formatDate(endDate) && task.timeSpentOnDay[workLogDate] >= minTimeMs) {
                   const timeMinutes = Math.round(task.timeSpentOnDay[workLogDate] / 60000);
-                  pushEntry({ date: workLogDate, project: projects[task.projectId] || '', title: task.title, timeMinutes, status: 'WIP', notes: task.notes || '', taskId: task.id });
+                  pushEntry({ date: workLogDate, project: projects[task.projectId] || '', title: task.title, timeMinutes, status: 'WIP', tags: formatTaskTags(task.tagIds, tags), notes: task.notes || '', taskId: task.id });
                 }
               });
             }
@@ -2530,7 +2586,7 @@
                 Object.keys(subtask.timeSpentOnDay).forEach(subDate => {
                   if (subDate >= formatDate(startDate) && subDate <= formatDate(endDate) && subtask.timeSpentOnDay[subDate] >= minTimeMs) {
                     const subTimeMinutes = Math.round(subtask.timeSpentOnDay[subDate] / 60000);
-                    pushEntry({ date: subDate, project: projects[subtask.projectId] || projects[task.projectId] || '', title: '↳ ' + subtask.title, timeMinutes: subTimeMinutes, status: subtask.isInProgress ? 'WIP' : '', notes: subtask.notes || '', taskId: task.id });
+                    pushEntry({ date: subDate, project: projects[subtask.projectId] || projects[task.projectId] || '', title: '↳ ' + subtask.title, timeMinutes: subTimeMinutes, status: subtask.isInProgress ? 'WIP' : '', tags: formatTaskTags(subtask.tagIds, tags), notes: subtask.notes || '', taskId: task.id });
                   }
                 });
               }
@@ -2546,7 +2602,7 @@
               // choose dueDay first if present, else fallback to plannedAt
               let dateKey = task.dueDay || (task.plannedAt ? formatDate(new Date(task.plannedAt)) : null);
               if (dateKey) {
-                pushEntry({ date: dateKey, project: projects[task.projectId] || '', title: task.title, timeMinutes: 0, status: 'OVERDUE', notes: task.notes || '', taskId: task.id });
+                pushEntry({ date: dateKey, project: projects[task.projectId] || '', title: task.title, timeMinutes: 0, status: 'OVERDUE', tags: formatTaskTags(task.tagIds, tags), notes: task.notes || '', taskId: task.id });
               }
             });
           }
@@ -2570,15 +2626,19 @@
         Object.keys(groups).forEach(k => groups[k].sort(comparator));
 
         // Build columns list from saved preferences or default order
-        const defaultCols = ['date','project','title','time','status','notes'];
+        const defaultCols = ['date','project','tags','title','time','status','notes'];
         let requestedCols = (preferences.tableColumns && Array.isArray(preferences.tableColumns))
           ? preferences.tableColumns.slice()
           : defaultCols.slice();
         // ensure defaults are present so user can re-add later if removed
         defaultCols.forEach(c => { if (!requestedCols.includes(c)) requestedCols.push(c); });
-        // respect showNotesColumn preference when generating table
-        const cols = requestedCols.filter(c => c !== 'notes' || preferences.showNotesColumn !== false);
-        const headerLabel = { date: 'Date', project: 'Project', title: 'Task Title', time: 'Time Spent', status: 'Status', notes: 'Notes' };
+        // respect showNotesColumn preference, and gate the Tags column on the
+        // Show tags toggle so it stays off by default (like the simple view)
+        const showTagsColumn = document.getElementById('showTags')?.checked === true;
+        const cols = requestedCols.filter(c =>
+          (c !== 'notes' || preferences.showNotesColumn !== false) &&
+          (c !== 'tags' || showTagsColumn));
+        const headerLabel = { date: 'Date', project: 'Project', tags: 'Tags', title: 'Task Title', time: 'Time Spent', status: 'Status', notes: 'Notes' };
 
         // Build markdown table output header (rest of rows handled by helper)
         const showTotals = document.getElementById('showTotalTime')?.checked;
@@ -2742,6 +2802,7 @@
           preferences.groupBy = document.getElementById('groupBy').value;
           preferences.showDate = document.getElementById('showDate').checked;
           preferences.showProject = document.getElementById('showProject').checked;
+          preferences.showTags = document.getElementById('showTags').checked;
           preferences.excludeEmptyDates = document.getElementById('excludeEmptyDates').checked;
           preferences.includeNotes = document.getElementById('includeNotes').checked;
           preferences.includeOverdue = document.getElementById('includeOverdue').checked;
@@ -3012,6 +3073,7 @@
         'groupBy',
         'showDate',
         'showProject',
+        'showTags',
         'excludeEmptyDates',
         'includeNotes',
         'includeOverdue',
@@ -3037,7 +3099,8 @@
       function updateDisplayOptionVisibility() {
         const isTable = document.getElementById('outputFormat')?.value === 'table';
         // showProject only affects the simple/list output (the table has its own
-        // Project column), so hide it in table mode.
+        // Project column), so hide it in table mode. showTags stays visible
+        // because it also gates the table's Tags column.
         ['showDate','showProject','includeNotes','showTimeSpent','showTotalTime'].forEach(id => {
           const el = document.getElementById(id);
           if (el) {
@@ -3067,6 +3130,15 @@
         tableColumnsListEl.addEventListener('dragend', () => {
           preferences.tableColumns = getTableColumnsOrder();
           preferencesHasChanges = true;
+        });
+      }
+
+      // The Tags column appears in the orderable list only while Show tags is on,
+      // so re-render it when the toggle flips.
+      const showTagsEl = document.getElementById('showTags');
+      if (showTagsEl) {
+        showTagsEl.addEventListener('change', () => {
+          renderTableColumnsUI();
         });
       }
 

--- a/date-range-reporter/index.html
+++ b/date-range-reporter/index.html
@@ -870,6 +870,15 @@
             </div>
             <div class="toggle-row">
               <div class="toggle-content">
+                <label for="showProject">Show project</label>
+              </div>
+              <label class="toggle-switch">
+                <input type="checkbox" id="showProject" checked style="display: none;" />
+                <span class="toggle-slider"></span>
+              </label>
+            </div>
+            <div class="toggle-row">
+              <div class="toggle-content">
                 <label for="includeNotes">Show task notes</label>
               </div>
               <label class="toggle-switch">
@@ -1043,7 +1052,7 @@
       // Exposed globally so tests can inspect/update preferences via `window.preferences`
       var preferences = {
         groupBy: 'date',
-        showProject: false,
+        showProject: true,
         showDate: false,
         excludeEmptyDates: true,
         includeNotes: false,
@@ -1521,7 +1530,8 @@
         // Filter out empty dates if checkbox is checked
         const excludeEmpty = document.getElementById('excludeEmptyDates').checked;
         const includeNotes = document.getElementById('includeNotes').checked;
-        const datesToShow = excludeEmpty 
+        const showProject = document.getElementById('showProject')?.checked !== false;
+        const datesToShow = excludeEmpty
           ? sortedDates.filter(dateStr => tasksByDate[dateStr].length > 0)
           : sortedDates;
 
@@ -1550,10 +1560,10 @@
               }
               
               // Optionally show project name
-              const projectName = task.projectId && projects[task.projectId] 
-                ? ` [${projects[task.projectId]}]` 
+              const projectName = showProject && task.projectId && projects[task.projectId]
+                ? ` [${projects[task.projectId]}]`
                 : '';
-              
+
               reportText += `- ${task.title}${projectName}${timeSpent}${statusIndicator}\n`;
               
               // Include subtasks indented under parent task
@@ -1564,10 +1574,10 @@
                     ? ` *(${Math.round(subtask.timeSpentOnDay[subtaskDateForTimeSpent] / 60000)} min)*`
                     : '';
                   const subtaskStatusIndicator = subtask.isInProgress ? ' WIP' : (subtask.isDone ? ' DONE ✅' : '');
-                  const subtaskProjectName = subtask.projectId && projects[subtask.projectId]
+                  const subtaskProjectName = showProject && subtask.projectId && projects[subtask.projectId]
                     ? ` [${projects[subtask.projectId]}]`
                     : '';
-                  
+
                   reportText += `  - ${subtask.title}${subtaskProjectName}${subtaskTimeSpent}${subtaskStatusIndicator}\n`;
                   
                   // Include notes for subtask if applicable
@@ -2031,6 +2041,14 @@
                   preferences.includeOverdue = preferences.includeMissedRecurring;
                   delete preferences.includeMissedRecurring;
                 }
+                // The inline project name used to be shown unconditionally (the
+                // showProject toggle was never wired up). Preserve that behavior
+                // for existing users the first time they load with the real
+                // toggle, then respect their choice afterwards.
+                if (preferences.showProjectMigrated === undefined) {
+                  preferences.showProject = true;
+                  preferences.showProjectMigrated = true;
+                }
                 applyPreferences();
               }
             }
@@ -2170,6 +2188,7 @@
       function applyPreferences() {
         const groupByEl = document.getElementById('groupBy');
         const showDateEl = document.getElementById('showDate');
+        const showProjectEl = document.getElementById('showProject');
         const excludeEmptyDatesEl = document.getElementById('excludeEmptyDates');
         const includeNotesEl = document.getElementById('includeNotes');
         const includeOverdueEl = document.getElementById('includeOverdue');
@@ -2180,6 +2199,7 @@
         
         if (groupByEl) groupByEl.value = preferences.groupBy;
         if (showDateEl) showDateEl.checked = preferences.showDate;
+        if (showProjectEl) showProjectEl.checked = preferences.showProject;
         if (excludeEmptyDatesEl) excludeEmptyDatesEl.checked = preferences.excludeEmptyDates;
         if (includeNotesEl) includeNotesEl.checked = preferences.includeNotes;
         if (includeOverdueEl) includeOverdueEl.checked = preferences.includeOverdue;
@@ -2721,6 +2741,7 @@
         try {
           preferences.groupBy = document.getElementById('groupBy').value;
           preferences.showDate = document.getElementById('showDate').checked;
+          preferences.showProject = document.getElementById('showProject').checked;
           preferences.excludeEmptyDates = document.getElementById('excludeEmptyDates').checked;
           preferences.includeNotes = document.getElementById('includeNotes').checked;
           preferences.includeOverdue = document.getElementById('includeOverdue').checked;
@@ -2990,6 +3011,7 @@
         'outputFormat',
         'groupBy',
         'showDate',
+        'showProject',
         'excludeEmptyDates',
         'includeNotes',
         'includeOverdue',
@@ -3014,7 +3036,9 @@
       const outputFormatEl = document.getElementById('outputFormat');
       function updateDisplayOptionVisibility() {
         const isTable = document.getElementById('outputFormat')?.value === 'table';
-        ['showDate','includeNotes','showTimeSpent','showTotalTime'].forEach(id => {
+        // showProject only affects the simple/list output (the table has its own
+        // Project column), so hide it in table mode.
+        ['showDate','showProject','includeNotes','showTimeSpent','showTotalTime'].forEach(id => {
           const el = document.getElementById(id);
           if (el) {
             const row = el.closest('.toggle-row');

--- a/date-range-reporter/index.html
+++ b/date-range-reporter/index.html
@@ -2515,6 +2515,12 @@
         const minTimeMs = parseInt(document.getElementById('minTimeSpent').value) * 60000;
         // const includeNotes = document.getElementById('includeNotes').checked; // not used in table logic
         const showTimeSpent = document.getElementById('showTimeSpent').checked;
+        // When Show tags is off the Tags column is dropped anyway, so null the
+        // lookup to skip per-task tag formatting (formatTaskTags returns '' when
+        // tags is falsy).
+        if (document.getElementById('showTags')?.checked !== true) {
+          tags = null;
+        }
         const excludeEmpty = document.getElementById('excludeEmptyDates').checked;
         const groupBy = document.getElementById('groupBy').value;
 

--- a/date-range-reporter/manifest.json.template
+++ b/date-range-reporter/manifest.json.template
@@ -12,6 +12,8 @@
   "permissions": [
     "getTasks",
     "getArchivedTasks",
+    "getAllProjects",
+    "getAllTags",
     "showSnack",
     "persistDataSynced",
     "loadSyncedData"

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -20,6 +20,7 @@ describe('Date Range Reporter', () => {
       getTasks: vi.fn().mockResolvedValue([]),
       getArchivedTasks: vi.fn().mockResolvedValue([]),
       getAllProjects: vi.fn().mockResolvedValue([]),
+      getAllTags: vi.fn().mockResolvedValue([]),
       persistDataSynced: vi.fn().mockResolvedValue(undefined),
       loadSyncedData: vi.fn().mockResolvedValue(null),
       showSnack: vi.fn(),
@@ -3572,6 +3573,76 @@ describe('Date Range Reporter', () => {
       const messages = mockPluginAPI.showSnack.mock.calls.map(c => c[0].msg);
       expect(messages.some(m => /too large to save/i.test(m))).toBe(true);
       expect(messages.some(m => m === 'Failed to save report')).toBe(false);
+    });
+  });
+
+  describe('Task tags (#68)', () => {
+    const taskWithTags = {
+      id: 'task-tags',
+      title: 'Tagged Task',
+      isDone: true,
+      doneOn: new Date('2024-01-15T15:00:00').getTime(),
+      projectId: 'p1',
+      tagIds: ['t-backlog', 't-security'],
+      timeSpentOnDay: { '2024-01-15': 3600000 },
+    };
+
+    async function generate(tags = []) {
+      mockPluginAPI.getTasks.mockResolvedValue([taskWithTags]);
+      mockPluginAPI.getAllProjects.mockResolvedValue([{ id: 'p1', title: 'Inbox' }]);
+      mockPluginAPI.getAllTags.mockResolvedValue(tags);
+      document.getElementById('startDate').value = '2024-01-15';
+      document.getElementById('endDate').value = '2024-01-15';
+      await window.generateReport();
+      return document.getElementById('modalReportContent').value;
+    }
+
+    const defaultTags = [
+      { id: 't-backlog', title: 'backlog' },
+      { id: 't-security', title: 'security' },
+    ];
+
+    it('renders tags as #tokens after the project when Show tags is on', async () => {
+      document.getElementById('showTags').checked = true;
+      const report = await generate(defaultTags);
+      const line = report.split('\n').find(l => l.includes('Tagged Task'));
+      expect(line).toContain('[Inbox] #backlog #security');
+    });
+
+    it('hides tags by default (Show tags off)', async () => {
+      // showTags defaults to false
+      const report = await generate(defaultTags);
+      const line = report.split('\n').find(l => l.includes('Tagged Task'));
+      expect(line).not.toContain('#backlog');
+      expect(line).toContain('[Inbox]');
+    });
+
+    it('skips the special Today tag', async () => {
+      document.getElementById('showTags').checked = true;
+      const report = await generate([
+        { id: 'TODAY', title: 'Today' },
+        { id: 't-backlog', title: 'backlog' },
+      ]);
+      const line = report.split('\n').find(l => l.includes('Tagged Task'));
+      expect(line).toContain('#backlog');
+      expect(line).not.toContain('#Today');
+    });
+
+    it('slugifies whitespace in multi-word tag titles', async () => {
+      document.getElementById('showTags').checked = true;
+      const report = await generate([
+        { id: 't-backlog', title: 'backlog' },
+        { id: 't-security', title: 'in progress' },
+      ]);
+      const line = report.split('\n').find(l => l.includes('Tagged Task'));
+      expect(line).toContain('#in-progress');
+    });
+
+    it('omits the project inline when Show project is off', async () => {
+      document.getElementById('showProject').checked = false;
+      const report = await generate(defaultTags);
+      const line = report.split('\n').find(l => l.includes('Tagged Task'));
+      expect(line).not.toContain('[Inbox]');
     });
   });
 });


### PR DESCRIPTION
Closes #68.

Adds task tags to generated reports, plus a related fix for a dead display toggle.

## What changed

**Tags (#68)** — `date-range-reporter/index.html`
- Fetch tags via `PluginAPI.getAllTags()` (mirrors the existing project lookup) and render them as `#tag` tokens after the project name in **date-grouped**, **project-grouped**, and **table** reports, including subtasks.
- New **"Show tags"** toggle in Display Options, **off by default** — existing reports are unchanged until a user opts in.
- In **table mode**, the same toggle gates a new **Tags** column; the column only appears in the drag-to-order list while the toggle is on.
- The special SuperProductivity **"Today"** tag is omitted, and whitespace in tag titles is slugified so multi-word tags stay one token (`in progress` → `#in-progress`).
- Declares the `getAllTags` permission (and `getAllProjects`, which was already used but never declared).

**Dead-toggle fix** (separate commit) — the `showProject` preference existed in defaults but had no checkbox and was never read, so the inline project name was always shown. It's now a real **"Show project"** toggle, gated in rendering and hidden in table mode. A one-time migration preserves current behavior for existing users so nobody silently loses project names.

## Report output

```
- Do this [Inbox] #backlog #security *(82 min)* DONE ✅
```

## Testing

- `npm test` → **127/127 pass** (5 new tests: tags on/off, `#Today` filtered, slugify, project-off).
- `make build` → succeeds.

## Follow-up

An optional rendered-Markdown preview with colored tag chips is tracked separately in #71 (deferred; not needed for this change).
